### PR TITLE
rm quotes from `INFOPLIST_FILE`

### DIFF
--- a/ios/NativeStarterKit.xcodeproj/project.pbxproj
+++ b/ios/NativeStarterKit.xcodeproj/project.pbxproj
@@ -1254,7 +1254,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 				);
-				INFOPLIST_FILE = "NativeStarterKit-tvOS/Info.plist";
+				INFOPLIST_FILE = NativeStarterKit-tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1288,7 +1288,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 				);
-				INFOPLIST_FILE = "NativeStarterKit-tvOS/Info.plist";
+				INFOPLIST_FILE = NativeStarterKit-tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1317,7 +1317,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "NativeStarterKit-tvOSTests/Info.plist";
+				INFOPLIST_FILE = NativeStarterKit-tvOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1342,7 +1342,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "NativeStarterKit-tvOSTests/Info.plist";
+				INFOPLIST_FILE = NativeStarterKit-tvOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
caused issue with linking react-native-code-push v2.0.1-beta on node v8.1.2

Error:
```shell
rnpm-install info Android module react-native-code-push is already linked 
rnpm-install info iOS module react-native-code-push is already linked 
"CodePush.h" header already imported.
"jsCodeLocation" already pointing to "[CodePush bundleURL]".
fs.js:651
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/<path_to_app>/ios/"NativeStarterKit-tvOSTests/Info.plist"'
    at Object.fs.openSync (fs.js:651:18)
    at Object.fs.readFileSync (fs.js:553:33)
    at Object.<anonymous> (/<path_to_app>/node_modules/react-native-code-push/scripts/postlink/ios/postlink.js:63:24)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
/<path_to_app>/node_modules/react-native/local-cli/core/makeCommand.js:29
        throw new Error(`Error occured during executing "${command}" command`);
        ^

Error: Error occured during executing "node node_modules/react-native-code-push/scripts/postlink/run" command
    at ChildProcess.prelink (/<path_to_app>/node_modules/react-native/local-cli/core/makeCommand.js:29:15)
    at emitTwo (events.js:125:13)
    at ChildProcess.emit (events.js:213:7)
    at maybeClose (internal/child_process.js:897:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:208:5)
```